### PR TITLE
Add CMS HCC payment year var to Github Actions dbt commands

### DIFF
--- a/.github/workflows/dbt_v1.4.6_bigquery_build_full_refresh.yml
+++ b/.github/workflows/dbt_v1.4.6_bigquery_build_full_refresh.yml
@@ -28,7 +28,7 @@ jobs:
       - name: dbt-build
         uses: mwhitaker/dbt-action@v1.4.6
         with:
-          dbt_command: "dbt build --full-refresh --profiles-dir ./integration_tests/profiles/bigquery"
+          dbt_command: "dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}' --profiles-dir ./integration_tests/profiles/bigquery"
 
       - name: Get the result
         if: ${{ always() }}

--- a/.github/workflows/dbt_v1.4.6_redshift_build_full_refresh.yml
+++ b/.github/workflows/dbt_v1.4.6_redshift_build_full_refresh.yml
@@ -31,7 +31,7 @@ jobs:
       - name: dbt-build
         uses: mwhitaker/dbt-action@v1.4.6
         with:
-          dbt_command: "dbt build --full-refresh --profiles-dir ./integration_tests/profiles/redshift"
+          dbt_command: "dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}' --profiles-dir ./integration_tests/profiles/redshift"
 
       - name: Get the result
         if: ${{ always() }}

--- a/.github/workflows/dbt_v1.4.6_snowflake_build_full_refresh.yml
+++ b/.github/workflows/dbt_v1.4.6_snowflake_build_full_refresh.yml
@@ -33,7 +33,7 @@ jobs:
       - name: dbt-build
         uses: mwhitaker/dbt-action@v1.4.6
         with:
-          dbt_command: "dbt build --full-refresh --profiles-dir ./integration_tests/profiles/snowflake"
+          dbt_command: "dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}' --profiles-dir ./integration_tests/profiles/snowflake"
 
       - name: Get the result
         if: ${{ always() }}

--- a/.github/workflows/weekly_dbt_v1.4.6_bigquery_build_full_refresh.yml
+++ b/.github/workflows/weekly_dbt_v1.4.6_bigquery_build_full_refresh.yml
@@ -30,7 +30,7 @@ jobs:
       - name: dbt-build
         uses: mwhitaker/dbt-action@v1.4.6
         with:
-          dbt_command: "dbt build --full-refresh --profiles-dir ./integration_tests/profiles/bigquery "
+          dbt_command: "dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}' --profiles-dir ./integration_tests/profiles/bigquery"
 
       - name: Get the result
         if: ${{ always() }}

--- a/.github/workflows/weekly_dbt_v1.4.6_redshift_build_full_refresh.yml
+++ b/.github/workflows/weekly_dbt_v1.4.6_redshift_build_full_refresh.yml
@@ -33,7 +33,7 @@ jobs:
       - name: dbt-build
         uses: mwhitaker/dbt-action@v1.4.6
         with:
-          dbt_command: "dbt build --full-refresh --profiles-dir ./integration_tests/profiles/redshift"
+          dbt_command: "dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}' --profiles-dir ./integration_tests/profiles/redshift"
 
       - name: Get the result
         if: ${{ always() }}

--- a/.github/workflows/weekly_dbt_v1.4.6_snowflake_build_full_refresh.yml
+++ b/.github/workflows/weekly_dbt_v1.4.6_snowflake_build_full_refresh.yml
@@ -35,7 +35,7 @@ jobs:
       - name: dbt-build
         uses: mwhitaker/dbt-action@v1.4.6
         with:
-          dbt_command: "dbt build --full-refresh --profiles-dir ./integration_tests/profiles/snowflake"
+          dbt_command: "dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}' --profiles-dir ./integration_tests/profiles/snowflake"
 
       - name: Get the result
         if: ${{ always() }}


### PR DESCRIPTION
## Describe your changes
Added an appropriate cms hcc payment year var to the GitHub actions to ensure the tables are fully populated for this data set.


## How has this been tested?
Ran `dbt build --full-refresh --vars '{cms_hcc_payment_year: 2019}'` in Snowflake and verified output.


## Reviewer focus
n/a


## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [ ]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
